### PR TITLE
[FLINK] [flink-runtime] Fixed Flaky Test CheckpointCoordinatorTest#testTriggerAndDeclineCheckpointComplex

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -118,6 +118,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonMap;
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION;
@@ -1028,7 +1029,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 checkpointCoordinator.getPendingCheckpoints().get(checkpoint2Id);
 
         assertNotNull(checkpoint1);
-        assertEquals(checkpoint1Id, checkpoint1.getCheckpointId());
+        assertEquals(checkpoint1Id, checkpoint1.getCheckpointID());
         assertEquals(graph.getJobID(), checkpoint1.getJobId());
         assertEquals(2, checkpoint1.getNumberOfNonAcknowledgedTasks());
         assertEquals(0, checkpoint1.getNumberOfAcknowledgedTasks());
@@ -1037,7 +1038,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         assertFalse(checkpoint1.areTasksFullyAcknowledged());
 
         assertNotNull(checkpoint2);
-        assertEquals(checkpoint2Id, checkpoint2.getCheckpointId());
+        assertEquals(checkpoint2Id, checkpoint2.getCheckpointID());
         assertEquals(graph.getJobID(), checkpoint2.getJobId());
         assertEquals(2, checkpoint2.getNumberOfNonAcknowledgedTasks());
         assertEquals(0, checkpoint2.getNumberOfAcknowledgedTasks());
@@ -1051,8 +1052,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
                     gateway.getTriggeredCheckpoints(
                             vertex.getCurrentExecutionAttempt().getAttemptId());
             assertEquals(2, triggeredCheckpoints.size());
-            assertEquals(checkpoint1Id, triggeredCheckpoints.get(0).checkpointId);
-            assertEquals(checkpoint2Id, triggeredCheckpoints.get(1).checkpointId);
+            List<Long> triggeredCheckPointIds =
+                    triggeredCheckpoints.stream()
+                            .map(p -> p.checkpointId)
+                            .collect(Collectors.toList());
+            assertTrue(triggeredCheckPointIds.contains(checkpoint1Id));
+            assertTrue(triggeredCheckPointIds.contains(checkpoint2Id));
         }
 
         // decline checkpoint from one of the tasks, this should cancel the checkpoint


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request **fixes a Flaky Test** CheckpointCoordinatorTest#testTriggerAndDeclineCheckpointComplex found by using the NonDex tool - https://github.com/TestingResearchIllinois/NonDex.*

*Also, **updated deprecated method** org.apache.flink.runtime.checkpoint.PendingCheckpoint#getCheckpointId to org.apache.flink.runtime.checkpoint.PendingCheckpoint#getCheckpointID*

### Error in NonDex

```
Assertion error in line  "assertEquals(checkpoint1Id, triggeredCheckpoints.get(0).checkpointId);"	
[ERROR]   CheckpointCoordinatorTest.testTriggerAndDeclineCheckpointComplex:1054 expected:<2> but was:<1>
```

### Analysis of the error

  - *The value of checkpoint1Id and checkpoint2Id are retrieved by iterating over a HashMap. Hence, they are not deterministic.*
  - *triggeredCheckpoints.get(0).checkpointId and triggeredCheckpoints.get(1).checkpointId are constants.*
  - *The assertions may fail in some scenarios as there is no guarentee of the order of values returned by the iterator over the HashMap.*

## Brief change log
Used the contains method in the test case assertion to compare values. This way we can check if checkpoint1Id and checkpoint2Id are present in the triggeredCheckpoints list irrespective of the order (the order is not important here according to the logic in code).
So, irrespective of the order in which the checkpoint values are returned by the HashMap, we will be able to make the correct assertions.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

## Alternate Fix
Use a LinkedHashMap instead of a HashMap to maintain the order in which the elements are returned.
[akshathsk/flink/pull/2](https://github.com/akshathsk/flink/pull/2)
